### PR TITLE
feat: add admin login

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,11 +2,11 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Video, LogOut, Menu, X, User, Plus, Edit } from "lucide-react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { Suspense } from "react"
 
 const navigation = [
@@ -16,7 +16,21 @@ const navigation = [
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const router = useRouter()
   const pathname = usePathname()
+
+  useEffect(() => {
+    const loggedIn =
+      typeof window !== "undefined" &&
+      localStorage.getItem("adminLoggedIn") === "true"
+    if (!loggedIn && pathname !== "/admin/login") {
+      router.replace("/admin/login")
+    }
+  }, [pathname, router])
+
+  if (pathname === "/admin/login") {
+    return <>{children}</>
+  }
 
   const user = {
     name: "Admin",
@@ -116,7 +130,14 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                   <div className="text-sm font-medium text-foreground">{user.name}</div>
                   <div className="text-xs text-muted-foreground">{user.role}</div>
                 </div>
-                <Button variant="ghost" size="sm">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    localStorage.removeItem("adminLoggedIn")
+                    router.push("/admin/login")
+                  }}
+                >
                   <LogOut className="h-4 w-4" />
                 </Button>
               </div>

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useState, FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Card } from "@/components/ui/card"
+
+export default function AdminLogin() {
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (email === "kodiji@gmail.com" && password === "admin") {
+      if (typeof window !== "undefined") {
+        localStorage.setItem("adminLoggedIn", "true")
+      }
+      router.push("/admin")
+    } else {
+      setError("Invalid credentials")
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Card className="p-8 w-full max-w-sm">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <Button type="submit" className="w-full">
+            Login
+          </Button>
+        </form>
+      </Card>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add admin login page with email and password check
- protect admin routes via local storage auth and logout support

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68b31780f48c8333b11085d5b8a7ba7b