### PR TITLE
feat: add admin logout page

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -133,12 +133,11 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => {
-                    localStorage.removeItem("adminLoggedIn")
-                    router.push("/admin/login")
-                  }}
+                  asChild
                 >
-                  <LogOut className="h-4 w-4" />
+                  <Link href="/admin/logout">
+                    <LogOut className="h-4 w-4" />
+                  </Link>
                 </Button>
               </div>
             </div>

--- a/app/admin/logout/page.tsx
+++ b/app/admin/logout/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function AdminLogout() {
+  const router = useRouter();
+
+  useEffect(() => {
+    localStorage.removeItem("adminLoggedIn");
+    localStorage.removeItem("admin_token");
+    localStorage.removeItem("admin_user");
+    router.replace("/admin/login");
+  }, [router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
+      <p>Logging out...</p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add admin logout page to clear stored auth and redirect
- update admin layout to link to logout page

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b322529e8c83339517bdfda3a7f861